### PR TITLE
feat(server/functions): add RegisterInventory

### DIFF
--- a/server/functions.lua
+++ b/server/functions.lua
@@ -660,6 +660,25 @@ end
 
 exports('CreateInventory', CreateInventory)
 
+--- Registers or updates an inventory entry.
+--- @param identifier string                      -- The unique identifier for the inventory.
+--- @param data table|nil                         -- Optional metadata for the inventory.
+---        @field label string|nil                -- Display label for the inventory.
+---        @field maxweight number|nil            -- Maximum weight capacity.
+---        @field slots number|nil                -- Number of inventory slots.
+function RegisterInventory(identifier, data)
+    if type(identifier) ~= "string" then return end
+    if not Inventories[identifier] then
+        CreateInventory(identifier, data)
+    else
+        Inventories[identifier].maxweight = (data and data.maxweight) or Config.StashSize.maxweight
+        Inventories[identifier].slots = (data and data.slots) or Config.StashSize.slots
+        Inventories[identifier].label = (data and data.label) or identifier
+    end
+end
+
+exports('RegisterInventory', RegisterInventory)
+
 --- Retrieves an inventory by its identifier.
 --- @param identifier string The identifier of the inventory to retrieve.
 --- @return table|nil - The inventory object if found, nil otherwise.


### PR DESCRIPTION
## Description

This PR introduces a new function, RegisterInventory, which ensures that inventories loaded from the database are fully initialized with the correct metadata (label, maxweight, and slots).

Currently, qb-inventory only loads items and isOpen when restoring inventories from the database during server startup. This means that any script interacting with a stash before it has been opened at least once will encounter issues, because maxweight, slots, and label are still nil until OpenInventory runs. This results in errors during weight checks or item insertion, especially for stashes created by external resources on startup or server restarts.

RegisterInventory resolves this by:

Creating the inventory if it does not exist

Updating/normalizing metadata for existing inventories using supplied values or Config.StashSize defaults

Mirroring the behavior of InitializeInventory and metadata setup inside OpenInventory

This provides a proper initialization path for third-party scripts (e.g., job systems, mechanic scripts, stash generators) to ensure inventories are fully usable immediately after registration, even before a player opens them.

A new export (RegisterInventory) is included so external resources can safely register or update stashes in a consistent, officially supported way.

This change is fully backwards compatible and does not modify existing DB structure or stash creation workflows.

## Checklist

- [x ] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x ] My code fits the style guidelines.
- [ x] My PR fits the contribution guidelines.
