### PR TITLE
fix(server/functions): make CreateInventory idempotent on existing inventories, consolidate inventory resolvers

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -3,7 +3,7 @@ game 'gta5'
 lua54 'yes'
 author 'Kakarot'
 description 'Player inventory system providing a variety of features for storing and managing items'
-version '2.1.0'
+version '2.2.0'
 
 shared_scripts {
     '@qb-core/shared/locale.lua',

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -1,14 +1,21 @@
 -- Local Functions
 
-local function InitializeInventory(inventoryId, data)
-    Inventories[inventoryId] = {
-        items = {},
-        isOpen = false,
-        label = data and data.label or inventoryId,
-        maxweight = data and data.maxweight or Config.StashSize.maxweight,
-        slots = data and data.slots or Config.StashSize.slots
-    }
-    return Inventories[inventoryId]
+--- Creates an inventory if missing, then fills in any metadata the caller did not supply.
+--- @param identifier string
+--- @param data table|nil Optional metadata: label, maxweight, slots.
+--- @return table - The inventory.
+local function ResolveInventory(identifier, data)
+    local inventory = Inventories[identifier]
+    if not inventory then
+        inventory = { items = {}, isOpen = false }
+        Inventories[identifier] = inventory
+    end
+
+    inventory.label = (data and data.label) or inventory.label or identifier
+    inventory.maxweight = (data and data.maxweight) or inventory.maxweight or Config.StashSize.maxweight
+    inventory.slots = (data and data.slots) or inventory.slots or Config.StashSize.slots
+
+    return inventory
 end
 
 local function GetFirstFreeSlot(items, maxSlots)
@@ -46,6 +53,27 @@ local function SetupShopItems(shopItems)
         end
     end
     return items
+end
+
+--- Resolves an identifier to its items and capacity.
+--- @param identifier string|number The identifier of a player, inventory or drop.
+--- @param requireCapacity boolean|nil Refuse inventories whose capacity is not set yet.
+--- @return table|nil items, number|nil maxweight, number|nil slots, table|nil player
+local function ResolveTarget(identifier, requireCapacity)
+    local player = exports['qb-core']:GetPlayer(identifier)
+    if player then
+        return player.PlayerData.items, Config.MaxWeight, Config.MaxSlots, player
+    end
+
+    local inventory = Inventories[identifier] or Drops[identifier]
+    if not inventory then return nil end
+
+    if requireCapacity and (not inventory.maxweight or not inventory.slots) then
+        print(('Inventory %s has no capacity set, create or open it first'):format(identifier))
+        return nil
+    end
+
+    return inventory.items, inventory.maxweight, inventory.slots
 end
 
 -- Exported Functions
@@ -306,20 +334,9 @@ exports('GetItemsByName', GetItemsByName)
 
 --- Retrieves the total count of used and free slots for a player or an inventory.
 --- @param identifier number|string The player's identifier or the identifier of an inventory or drop.
---- @return number, number - The total count of used slots and the total count of free slots. If no inventory is found, returns 0 and the maximum slots.
+--- @return number, number|nil - The total count of used slots and the total count of free slots. If no usable inventory is found, returns 0 and nil.
 function GetSlots(identifier)
-    local inventory, maxSlots
-    local player = exports['qb-core']:GetPlayer(identifier)
-    if player then
-        inventory = player.PlayerData.items
-        maxSlots = Config.MaxSlots
-    elseif Inventories[identifier] then
-        inventory = Inventories[identifier].items
-        maxSlots = Inventories[identifier].slots
-    elseif Drops[identifier] then
-        inventory = Drops[identifier].items
-        maxSlots = Drops[identifier].slots
-    end
+    local inventory, _, maxSlots = ResolveTarget(identifier, true)
     if not inventory then return 0, maxSlots end
     local slotsUsed = 0
     for _, v in pairs(inventory) do
@@ -365,41 +382,29 @@ exports('GetItemCount', GetItemCount)
 --- @return boolean - Returns true if the item can be added, false otherwise.
 --- @return string|nil - Returns a string indicating the reason why the item cannot be added (e.g., 'weight' or 'slots'), or nil if it can be added.
 function CanAddItem(identifier, item, amount)
-    local Player = exports['qb-core']:GetPlayer(identifier)
-
     local itemData = QBCore.Shared.Items[item:lower()]
     if not itemData then return false end
 
-    local inventory, items
-    if Player then
-        inventory = {
-            maxweight = Config.MaxWeight,
-            slots = Config.MaxSlots
-        }
-        items = Player.PlayerData.items
-    elseif Inventories[identifier] then
-        inventory = Inventories[identifier]
-        items = Inventories[identifier].items
-    end
+    local items, maxweight, slots = ResolveTarget(identifier, true)
 
-    if not inventory then
-        print('CanAddItem: Inventory not found')
+    if not items then
+        print(('CanAddItem: Inventory not found: %s'):format(identifier))
         return false
     end
 
     local weight = itemData.weight * amount
     local totalWeight = GetTotalWeight(items) + weight
-    if totalWeight > inventory.maxweight then
+    if totalWeight > maxweight then
         return false, 'weight'
     end
 
     local slotsUsed, _ = GetSlots(identifier)
 
-    if slotsUsed >= inventory.slots then
+    if slotsUsed >= slots then
         for _, v in pairs(items) do
             if v.name == itemData.name then
                 if itemData.unique then break end
-                print(('CanAddItem: Player %s has no free slots for item %s, but has %d of it already'):format(identifier, itemData.name, v.amount))
+                print(('CanAddItem: Inventory %s has no free slots for item %s, but has %d of it already'):format(identifier, itemData.name, v.amount))
                 goto continue
             end
         end
@@ -646,10 +651,7 @@ function OpenInventory(source, identifier, data)
         return
     end
 
-    if not inventory then inventory = InitializeInventory(identifier, data) end
-    inventory.maxweight = (data and data.maxweight) or (inventory and inventory.maxweight) or Config.StashSize.maxweight
-    inventory.slots = (data and data.slots) or (inventory and inventory.slots) or Config.StashSize.slots
-    inventory.label = (data and data.label) or (inventory and inventory.label) or identifier
+    inventory = ResolveInventory(identifier, data)
     local hookData = buildHookData('InventoryOpened', source, QBPlayer, identifier, identifier, inventory)
     if TriggerHook('InventoryOpened', GetInventoryType(identifier), hookData) == false then return end
     inventory.isOpen = source
@@ -667,13 +669,12 @@ end
 
 exports('OpenInventory', OpenInventory)
 
---- Creates a new inventory and returns the inventory object.
+--- Creates an inventory, or fills in the metadata of one that already exists.
 --- @param identifier string The identifier of the inventory to create.
---- @param data table Additional data for initializing the inventory.
+--- @param data table|nil Optional metadata: label, maxweight, slots.
 function CreateInventory(identifier, data)
-    if Inventories[identifier] then return end
-    if not identifier then return end
-    Inventories[identifier] = InitializeInventory(identifier, data)
+    if type(identifier) ~= 'string' then return end
+    ResolveInventory(identifier, data)
 end
 
 exports('CreateInventory', CreateInventory)
@@ -712,25 +713,10 @@ function AddItem(identifier, item, amount, slot, info, reason, isInternalMove)
         print('AddItem: Invalid item')
         return false
     end
-    local inventory, inventoryWeight, inventorySlots
-    local player = exports['qb-core']:GetPlayer(identifier)
-
-    if player then
-        inventory = player.PlayerData.items
-        inventoryWeight = Config.MaxWeight
-        inventorySlots = Config.MaxSlots
-    elseif Inventories[identifier] then
-        inventory = Inventories[identifier].items
-        inventoryWeight = Inventories[identifier].maxweight
-        inventorySlots = Inventories[identifier].slots
-    elseif Drops[identifier] then
-        inventory = Drops[identifier].items
-        inventoryWeight = Drops[identifier].maxweight
-        inventorySlots = Drops[identifier].slots
-    end
+    local inventory, inventoryWeight, inventorySlots, player = ResolveTarget(identifier, true)
 
     if not inventory then
-        print('AddItem: Inventory not found')
+        print(('AddItem: Inventory not found: %s'):format(identifier))
         return false
     end
 
@@ -826,19 +812,10 @@ function RemoveItem(identifier, item, amount, slot, reason, isInternalMove)
         return false
     end
 
-    local inventory
-    local player = exports['qb-core']:GetPlayer(identifier)
-
-    if player then
-        inventory = player.PlayerData.items
-    elseif Inventories[identifier] then
-        inventory = Inventories[identifier].items
-    elseif Drops[identifier] then
-        inventory = Drops[identifier].items
-    end
+    local inventory, _, _, player = ResolveTarget(identifier)
 
     if not inventory then
-        print('RemoveItem: Inventory not found')
+        print(('RemoveItem: Inventory not found: %s'):format(identifier))
         return false
     end
 


### PR DESCRIPTION
## Summary

`CreateInventory` early-returned whenever the identifier was already a key in
`Inventories`. That treated "key present" as "inventory ready to use", and the two
diverge for inventories cached from the database at startup,
which carry `items` and `isOpen` but no `label`, `maxweight` or `slots`.

So for any inventory with a saved row, on any restart, before a player opened it:
`CreateInventory(id, data)` silently discarded the sizes passed to it, and `AddItem`,
`CanAddItem` and `GetSlots` then threw on the nil capacity.

- `InitializeInventory` becomes `ResolveInventory`, which creates the container only
  when absent, then fills in metadata, preserving existing values before falling back
  to `Config.StashSize`. Non-destructive, so it is safe to call on an inventory that
  already exists.
- `OpenInventory` loses its duplicated copy of the same fallback chain.
- `ResolveTarget` replaces the identifier dispatch copy-pasted across `AddItem`,
  `RemoveItem`, `CanAddItem` and `GetSlots`. Its `requireCapacity` flag makes the
  first three refuse and log rather than throw when capacity is unset; `RemoveItem`
  opts out, since removing from an unconfigured inventory must always work.

## Related issue (PR)

Addresses problem reported in #636 - diverged into making CreateInventory idempotent to avoid a second adjacent method (`CreateInventory` vs `RegisterInventory`)

The diagnosis and reproduction are @t1ger-scripts'. That PR added a separate
`RegisterInventory` export to fill the metadata in; this fixes it from the other end
by making `CreateInventory` non-destructive, so no second entry point is needed and
resources already calling it are fixed without changes.

## Change type

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactor, maintenance, or performance improvement

## Testing

- FXServer artifact: b35265
- qb-core version or commit: 1.3.0
- Resource version or commit: 2.1.0 / f6229cb
- Server operating system: Windows Server 2022
- Test steps and results:

Reproduction of the original bug and the fix, using temporary console commands calling
`CreateInventory`, `AddItem`, `RemoveItem` and `GetInventory` directly:

1. Headless `CreateInventory` with sizes, then `AddItem` on a new identifier, added.
2. Opened the inventory in game, confirmed the item and the supplied limits, closed it
   so the row was written to the database.
3. `restart qb-inventory` - reloaded from the database, capacity now nil. Confirmed items intact.
4. `AddItem` with no preceding `CreateInventory` - returned `false` and logged the
   inventory name. This previously threw *attempt to compare number with nil*.
5. `RemoveItem` on that same uninitialised state - succeeded as intended.
6. `CreateInventory` then `AddItem` on that state - added. Confirmed both items present
   afterwards, verifying the resolve did not wipe existing items.

## Compatibility and migration


Export behaviour changes:

- `CreateInventory` on an inventory that already exists now applies the `data` you
  pass, where it previously ignored it. Omitting `data` still preserves whatever is
  already set, so no caller loses configured sizes.
- `CreateInventory` now requires a string identifier, matching the check `OpenInventory`
  already had. This closes a dead end rather than removing a capability: a numeric
  identifier could be created but never opened, so no caller could have had a working
  inventory that way. A caller passing a number now gets nothing instead of an
  unusable entry.
- `CanAddItem` now resolves `Drops`, which it did not previously. It returned
  "Inventory not found" for drop identifiers that `AddItem` accepted; it now matches.

Capacity remains caller-owned and is re-asserted on every open.

## Checklist

- [x] I agree to follow the [QBCore FiveM Code of Conduct](https://github.com/qbcore-fivem/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] My pull request title follows Conventional Commits, such as `fix(scope): ...` or `feat(scope): ...`.
- [ ] This pull request contains one focused change and does not include unrelated formatting or refactoring.
- [x] I tested the change on a current FXServer artifact with the relevant official resources and dependencies.
- [x] Existing repository checks and linting pass.
- [x] I documented new behavior and identified every breaking or migration-related change.
- [x] I added or updated configuration examples, SQL migrations, and translations where applicable.
- [x] I removed credentials, webhook URLs, license keys, database data, player identifiers, and other private information.
- [x] I have the right to submit all included code and assets under the repository's license.
- [x] I understand and reviewed all submitted code, including any AI-assisted code, and accept responsibility for its correctness and licensing.