### PR TITLE
fix(server): persist inventory changes outside the close event

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -3,7 +3,7 @@ game 'gta5'
 lua54 'yes'
 author 'Kakarot'
 description 'Player inventory system providing a variety of features for storing and managing items'
-version '2.2.0'
+version '2.2.1'
 
 shared_scripts {
     '@qb-core/shared/locale.lua',

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -779,6 +779,8 @@ function AddItem(identifier, item, amount, slot, info, reason, isInternalMove)
     end
 
     if player then player.SetPlayerData('items', inventory) end
+    local stash = Inventories[identifier]
+    if stash and not stash.isOpen then SaveInventoryItems(identifier) end
     if hookData then TriggerListener('ItemAdded', pendingItem.type, hookData) end
     local invName = player and GetPlayerName(identifier) .. ' (' .. identifier .. ')' or identifier
     local addReason = reason or 'No reason specified'
@@ -870,6 +872,9 @@ function RemoveItem(identifier, item, amount, slot, reason, isInternalMove)
             checkWeapon(identifier, item)
         end
     end
+
+    local stash = Inventories[identifier]
+    if stash and not stash.isOpen then SaveInventoryItems(identifier) end
 
     if hookData then TriggerListener('ItemRemoved', inventoryItem.type, hookData) end
 

--- a/server/main.lua
+++ b/server/main.lua
@@ -55,7 +55,7 @@ end)
 AddEventHandler('txAdmin:events:serverShuttingDown', function()
     for inventory, data in pairs(Inventories) do
         if data.isOpen then
-            MySQL.prepare('INSERT INTO inventories (identifier, items) VALUES (?, ?) ON DUPLICATE KEY UPDATE items = ?', { inventory, json.encode(data.items), json.encode(data.items) })
+            SaveInventoryItems(inventory)
         end
     end
 end)
@@ -149,6 +149,15 @@ end)
 
 -- Functions
 
+--- Writes an inventory's items to the database. Metadata is not persisted.
+--- @param identifier string The identifier of the inventory.
+function SaveInventoryItems(identifier)
+    local inventory = Inventories[identifier]
+    if not inventory then return end
+    local items = json.encode(inventory.items)
+    MySQL.prepare('INSERT INTO inventories (identifier, items) VALUES (?, ?) ON DUPLICATE KEY UPDATE items = ?', { identifier, items, items })
+end
+
 function checkWeapon(source, item)
     local currentWeapon = item
     local ped = GetPlayerPed(source)
@@ -207,7 +216,7 @@ RegisterNetEvent('qb-inventory:server:closeInventory', function(inventory)
     end
     if not Inventories[inventory] then return end
     Inventories[inventory].isOpen = false
-    MySQL.prepare('INSERT INTO inventories (identifier, items) VALUES (?, ?) ON DUPLICATE KEY UPDATE items = ?', { inventory, json.encode(Inventories[inventory].items), json.encode(Inventories[inventory].items) })
+    SaveInventoryItems(inventory)
 end)
 
 RegisterNetEvent('qb-inventory:server:useItem', function(item)

--- a/server/main.lua
+++ b/server/main.lua
@@ -132,6 +132,14 @@ AddEventHandler('onResourceStart', function(resourceName)
 end)
 
 AddEventHandler('onResourceStop', function(resourceName)
+    if resourceName == GetCurrentResourceName() then
+        for inventory, data in pairs(Inventories) do
+            if data.isOpen then
+                SaveInventoryItems(inventory)
+            end
+        end
+    end
+
     for _, eventData in pairs(Events) do
         for i = 1, #eventData.hooks do
             if eventData.hooks[i] and eventData.hooks[i].resource == resourceName then

--- a/server/main.lua
+++ b/server/main.lua
@@ -157,7 +157,7 @@ end)
 
 -- Functions
 
---- Writes an inventory's items to the database. Metadata is not persisted.
+--- Writes an inventory's items to the database.
 --- @param identifier string The identifier of the inventory.
 function SaveInventoryItems(identifier)
     local inventory = Inventories[identifier]


### PR DESCRIPTION
## Summary

Inventory persistence had three gaps:

* Inventories only reached the database on the close event (`server/main.lua:210`).
* The txAdmin shutdown handler wrote only inventories that were *currently open*, so
  anything mutated without being opened and closed was never persisted at all.
* `onResourceStop` did no saving, so a `restart qb-inventory` discarded in-memory
  state for every inventory, including open ones.

This closes all three:

* New `SaveInventoryItems(identifier)` helper holds the upsert; the shutdown and close
  handlers now call it instead of carrying their own copies of the SQL. This consolidates writes to one helper.
* `AddItem` and `RemoveItem` write immediately when the target is an `Inventories`
  entry that is not open, on the basis that an open inventory will get a close event
  and be saved then; the at-risk mutations are exactly the ones to closed inventories.
* `onResourceStop` flushes open inventories when qb-inventory itself stops.

The resulting invariant: a closed inventory is always current in the database, and an
open one is written on close, on shutdown, or on resource stop. Only a hard crash
mid-session loses anything. Both existing handlers keep their `isOpen` conditions,
which are now sufficient rather than gaps.

## Related issue

No issue. Found while working on #647; a headless `AddItem` to a stash nobody had opened succeeded in memory with no persistence.

## Change type

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactor, maintenance, or performance improvement

## Testing
- FXServer artifact: b35265
- qb-core version or commit: 1.3.0
- Resource version or commit: 2.2.1 / 2ff8fb2
- Server operating system: Windows Server 2022
- Test steps and results:

1. Headless `AddItem` to a closed stash, then `restart qb-inventory` with no open or
   close in between; item present afterwards. Previously lost.
2. Item dragged into a stash left open, then `restart qb-inventory`; item present.
   Previously lost. This exercises the `onResourceStop` flush
3. Dropped an item, dragged another into the bag, restarted, then checked
   `SELECT identifier FROM inventories WHERE identifier LIKE 'drop-%'`; empty, so
   drops remain memory-only and no phantom rows are created.
4. Open, add, close, restart; item present, close path unchanged.
5. `/giveitem` and a relog; player inventories unaffected.
   
## Compatibility and migration

None

## Checklist

- [x] I agree to follow the [QBCore FiveM Code of Conduct](https://github.com/qbcore-fivem/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] My pull request title follows Conventional Commits, such as `fix(scope): ...` or `feat(scope): ...`.
- [x] This pull request contains one focused change and does not include unrelated formatting or refactoring.
- [x] I tested the change on a current FXServer artifact with the relevant official resources and dependencies.
- [x] Existing repository checks and linting pass.
- [x] I documented new behavior and identified every breaking or migration-related change.
- [x] I added or updated configuration examples, SQL migrations, and translations where applicable.
- [x] I removed credentials, webhook URLs, license keys, database data, player identifiers, and other private information.
- [x] I have the right to submit all included code and assets under the repository's license.
- [x] I understand and reviewed all submitted code, including any AI-assisted code, and accept responsibility for its correctness and licensing.
