### PR TITLE
fix: shop error pane and vehicle storage defaults

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -3,7 +3,7 @@ game 'gta5'
 lua54 'yes'
 author 'Kakarot'
 description 'Player inventory system providing a variety of features for storing and managing items'
-version '2.2.1'
+version '2.2.2'
 
 shared_scripts {
     '@qb-core/shared/locale.lua',

--- a/html/app.js
+++ b/html/app.js
@@ -559,7 +559,7 @@ const InventoryContainer = Vue.createApp({
                                     amount: amountToTransfer,
                                 };
                             } else {
-                                this.inventoryError(sourceSlot);
+                                this.inventoryError(sourceSlot, "other");
                                 return;
                             }
                         }
@@ -571,10 +571,10 @@ const InventoryContainer = Vue.createApp({
                         delete sourceInventory[sourceSlot];
                     }
                 } else {
-                    this.inventoryError(sourceSlot);
+                    this.inventoryError(sourceSlot, "other");
                 }
             } catch (error) {
-                this.inventoryError(sourceSlot);
+                this.inventoryError(sourceSlot, "other");
             }
         },
         async dropItem(item, quantity) {

--- a/server/commands.lua
+++ b/server/commands.lua
@@ -121,14 +121,14 @@ RegisterCommand('inventory', function(source)
         if not inventory then return OpenInventory(source) end
         if inventory:find('trunk%-') then
             OpenInventory(source, inventory, {
-                slots = VehicleStorage[class] and VehicleStorage[class].trunkSlots or VehicleStorage.default.slots,
-                maxweight = VehicleStorage[class] and VehicleStorage[class].trunkWeight or VehicleStorage.default.maxWeight
+                slots = VehicleStorage[class] and VehicleStorage[class].trunkSlots or VehicleStorage.default.trunkSlots,
+                maxweight = VehicleStorage[class] and VehicleStorage[class].trunkWeight or VehicleStorage.default.trunkWeight
             })
             return
         elseif inventory:find('glovebox%-') then
             OpenInventory(source, inventory, {
-                slots = VehicleStorage[class] and VehicleStorage[class].gloveboxSlots or VehicleStorage.default.slots,
-                maxweight = VehicleStorage[class] and VehicleStorage[class].gloveboxWeight or VehicleStorage.default.maxWeight
+                slots = VehicleStorage[class] and VehicleStorage[class].gloveboxSlots or VehicleStorage.default.gloveboxSlots,
+                maxweight = VehicleStorage[class] and VehicleStorage[class].gloveboxWeight or VehicleStorage.default.gloveboxWeight
             })
             return
         end


### PR DESCRIPTION
## Summary

Two unrelated one-line fixes.

**Shop purchase errors highlighted the wrong pane.** Three failure paths in
`handlePurchase` (`html/app.js`) called `inventoryError(sourceSlot)` without the
second argument, so they fell back to the `inventory = "player"` default in the
signature. All three now pass `"other"`.

**Uncovered vehicle classes got stash-sized storage.** `server/commands.lua` fell
back to `VehicleStorage.default.slots` and `VehicleStorage.default.maxWeight`, but
the `default` block defines `trunkSlots`, `trunkWeight`, `gloveboxSlots` and
`gloveboxWeight`. Both fallbacks resolved to nil, so `OpenInventory` received
`{ slots = nil, maxweight = nil }` and landed on `Config.StashSize`. Classes 10
(Industrial) and 11 (Utility) are the two absent from `config/vehicles.lua`, so tow
trucks, tractors, trailers, mixers, tippers and flatbeds were getting 2,000kg / 100
slot trunks and gloveboxes instead of the intended 60kg / 35 and 10kg / 5. The
`default` block had never been reachable

## Related issue

No issue.

## Change type

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor, maintenance, or performance improvement

## Testing

<!-- Include the environment, versions, exact test steps, and observed results. -->

- FXServer artifact: b35265
- qb-core version or commit: 1.3.0
- Resource version or commit: 2.2.2 / 989b27a
- Server operating system: Windows Server 2022
- Test steps and results:

1. Attempted a shop purchase of 100 items with insufficient cash; the error flashed
   on the shop item in the shop pane.
2. Attempted a purchase with the inventory at its weight cap; same, correct pane.
3. Spawned a tow truck (Utility, class 11) and opened its glovebox;
   read 10kg, previously 2,000kg. Opened the trunk; read 60kg, previously 2,000kg.
4. Covered classes are structurally unaffected.

## Compatibility and migration

Behaviour note: Industrial and Utility class vehicles now have correctly sized trunks
and gloveboxes. On servers where players have been using those vehicles, existing
contents may exceed the corrected limit, in which case items are retained but nothing
further can be added until it is back under the cap.

## Checklist

- [x] I agree to follow the [QBCore FiveM Code of Conduct](https://github.com/qbcore-fivem/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] My pull request title follows Conventional Commits, such as `fix(scope): ...` or `feat(scope): ...`.
- [ ] This pull request contains one focused change and does not include unrelated formatting or refactoring.
- [x] I tested the change on a current FXServer artifact with the relevant official resources and dependencies.
- [x] Existing repository checks and linting pass.
- [x] I documented new behavior and identified every breaking or migration-related change.
- [x] I added or updated configuration examples, SQL migrations, and translations where applicable.
- [x] I removed credentials, webhook URLs, license keys, database data, player identifiers, and other private information.
- [x] I have the right to submit all included code and assets under the repository's license.
- [x] I understand and reviewed all submitted code, including any AI-assisted code, and accept responsibility for its correctness and licensing.
