### PR TITLE
fix(server): prevent unauthorized item moves to and from arbitrary inventories

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -3,7 +3,7 @@ game 'gta5'
 lua54 'yes'
 author 'Kakarot'
 description 'Player inventory system providing a variety of features for storing and managing items'
-version '2.2.2'
+version '2.2.3'
 
 shared_scripts {
     '@qb-core/shared/locale.lua',

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -538,6 +538,7 @@ function OpenInventoryById(source, targetId)
     local hookData = buildHookData('InventoryOpened', source, QBPlayer, targetId, TargetPlayer)
     if TriggerHook('InventoryOpened', 'player', hookData) == false then return end
     Wait(1500)
+    InventoryViewers[tonumber(targetId)] = source
     Player(targetId).state.inv_busy = true
     TriggerClientEvent('qb-inventory:client:openInventory', source, playerItems, formattedInventory)
     TriggerListener('InventoryOpened', 'player', hookData)

--- a/server/main.lua
+++ b/server/main.lua
@@ -1,6 +1,7 @@
 QBCore = exports['qb-core']:GetCoreObject()
 Inventories = {}
 Drops = {}
+InventoryViewers = {}
 RegisteredShops = {}
 Events = {
     ItemMoved = { hooks = {}, listeners = {} },
@@ -206,8 +207,9 @@ RegisterNetEvent('qb-inventory:server:closeInventory', function(inventory)
     if not QBPlayer then return end
     Player(source).state.inv_busy = false
     if inventory:find('shop%-') then return end
-    if inventory:find('otherplayer%-') then
-        local targetId = tonumber(inventory:match('otherplayer%-(.+)'))
+    if inventory:find('^otherplayer%-') then
+        local targetId = tonumber(inventory:match('^otherplayer%-(.+)'))
+        InventoryViewers[targetId] = nil
         Player(targetId).state.inv_busy = false
         return
     end
@@ -312,7 +314,7 @@ RegisterNetEvent('qb-inventory:server:openDrop', function(dropId)
         slots = drop.slots,
         inventory = drop.items
     }
-    drop.isOpen = true
+    drop.isOpen = src
     TriggerClientEvent('qb-inventory:client:openInventory', source, Player.PlayerData.items, formattedInventory)
 end)
 
@@ -371,7 +373,7 @@ QBCore.Functions.CreateCallback('qb-inventory:server:createDrop', function(sourc
                 coords = playerCoords,
                 maxweight = Config.DropSize.maxweight,
                 slots = Config.DropSize.slots,
-                isOpen = true
+                isOpen = src
             }
             TriggerClientEvent('qb-inventory:client:setupDropTarget', -1, dropId)
         else
@@ -530,13 +532,13 @@ local function getItem(inventoryId, src, slot)
         if Player and Player.PlayerData.items then
             items = Player.PlayerData.items
         end
-    elseif inventoryId:find('otherplayer-') then
-        local targetId = tonumber(inventoryId:match('otherplayer%-(.+)'))
+    elseif inventoryId:find('^otherplayer%-') then
+        local targetId = tonumber(inventoryId:match('^otherplayer%-(.+)'))
         local targetPlayer = QBCore.Functions.GetPlayer(targetId)
         if targetPlayer and targetPlayer.PlayerData.items then
             items = targetPlayer.PlayerData.items
         end
-    elseif inventoryId:find('drop-') == 1 then
+    elseif inventoryId:find('^drop%-') then
         if Drops[inventoryId] and Drops[inventoryId]['items'] then
             items = Drops[inventoryId]['items']
         end
@@ -554,24 +556,42 @@ local function getItem(inventoryId, src, slot)
     return nil
 end
 
+--- @param inventoryId string The inventory the client named.
+--- @param src number The player's server ID.
+--- @return boolean
+local function isOpenFor(inventoryId, src)
+    if inventoryId == 'player' then
+        return true
+    elseif inventoryId:find('^otherplayer%-') then
+        local targetId = tonumber(inventoryId:match('^otherplayer%-(.+)'))
+        return targetId ~= nil and InventoryViewers[targetId] == src
+    elseif inventoryId:find('^drop%-') then
+        return Drops[inventoryId] ~= nil and Drops[inventoryId].isOpen == src
+    else
+        return Inventories[inventoryId] ~= nil and Inventories[inventoryId].isOpen == src
+    end
+end
+
 local function getIdentifier(inventoryId, src)
     if inventoryId == 'player' then
         return src
-    elseif inventoryId:find('otherplayer-') then
-        return tonumber(inventoryId:match('otherplayer%-(.+)'))
+    elseif inventoryId:find('^otherplayer%-') then
+        return tonumber(inventoryId:match('^otherplayer%-(.+)'))
     else
         return inventoryId
     end
 end
 
 RegisterNetEvent('qb-inventory:server:SetInventoryData', function(fromInventory, toInventory, fromSlot, toSlot, fromAmount, toAmount)
+    if type(fromInventory) ~= 'string' or type(toInventory) ~= 'string' then return end
     if toInventory:find('shop%-') then return end
-    if not fromInventory or not toInventory or not fromSlot or not toSlot or not fromAmount or not toAmount or fromAmount < 0 or toAmount < 0 then return end
     local src = source
     local Player = QBCore.Functions.GetPlayer(src)
     if not Player then return end
 
     fromSlot, toSlot, fromAmount, toAmount = tonumber(fromSlot), tonumber(toSlot), tonumber(fromAmount), tonumber(toAmount)
+    if not fromSlot or not toSlot or not fromAmount or not toAmount or fromAmount < 0 or toAmount < 0 then return end
+    if not isOpenFor(fromInventory, src) or not isOpenFor(toInventory, src) then return end
 
     local fromItem = getItem(fromInventory, src, fromSlot)
     local toItem = getItem(toInventory, src, toSlot)

--- a/server/main.lua
+++ b/server/main.lua
@@ -46,9 +46,21 @@ end)
 -- Handlers
 
 AddEventHandler('playerDropped', function()
+    local src = source
     for _, inv in pairs(Inventories) do
-        if inv.isOpen == source then
+        if inv.isOpen == src then
             inv.isOpen = false
+        end
+    end
+    for _, drop in pairs(Drops) do
+        if drop.isOpen == src then
+            drop.isOpen = false
+        end
+    end
+    InventoryViewers[src] = nil
+    for targetId, viewer in pairs(InventoryViewers) do
+        if viewer == src then
+            InventoryViewers[targetId] = nil
         end
     end
 end)


### PR DESCRIPTION
## Summary

`qb-inventory:server:SetInventoryData` performed item moves between whatever two
inventories the client named, with no check that the player had either of them open.
The identifiers come straight from the client, so naming an inventory was sufficient
to act on it.

Exposure was in both directions and across every namespace (not just other players):

* `otherplayer-<id>` reached any online player's live items, with no proximity
  requirement and without their inventory being open.
* Stash, trunk and glovebox identifiers reached any inventory by name. Trunk
  identifiers are `trunk-<plate>` and plates are readable in game, so any parked
  vehicle's trunk was reachable from anywhere on the map.
* `drop-<id>` reached any drop.

Because both sides of the move were unchecked, this allowed items to be moved *into*
another player's inventory as well as out of it, so planting items and emptying
a stash into a drop were both possible alongside straightforward theft.

## Fix

* `isOpenFor(inventoryId, src)` verifies the recorded viewer before any item is read
  or moved, and is called for both sides of the move.
* Drops now record the viewer, `isOpen = source` rather than `true`, at both the
  creation and open sites.
* Player inventories gain `InventoryViewers[targetId] = viewerSrc`, written by
  `OpenInventoryById` and cleared on close and on disconnect.
* Amounts are coerced before being compared, so a non-numeric amount is rejected
  rather than throwing, and the inventory names are type-checked.

No authorization policy was added to qb-inventory. Whether to grant access remains
the caller's decision, which is why the decision for a distance check doesn't live in qb-inventory.
Also fixes a pre-existing leak that this made addressable: a player disconnecting
with a drop open left `isOpen` set forever, which stopped the cleanup thread deleting
the entity and made the bag permanently unopenable.

## Related issue

Closes #645 

## Change type

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor, maintenance, or performance improvement

## Testing

<!-- Include the environment, versions, exact test steps, and observed results. -->

- FXServer artifact: b35265
- qb-core version or commit: 1.3.0
- Resource version or commit: 2.2.3 / 0e0e0c5
- Server operating system: Windows Server 2022
- Test steps and results:

Attack reproduced with a temporary client command firing the net event directly.

1. Move from a closed trunk: rejected. Opened the trunk, identical command: succeeded,
   confirmed by closing and reopening.
2. Same against a closed drop: rejected. Opened: succeeded.
3. `otherplayer-` lifecycle, self-granted via `OpenInventoryById`: rejected before the
   grant, viewer recorded on open, move succeeded while open, viewer cleared on close,
   rejected again afterwards.
4. Disconnecting with a bag open: bag is openable again and despawns on the cleanup
   interval, where previously it was stuck permanently.

## Compatibility and migration

None

## Checklist

- [x] I agree to follow the [QBCore FiveM Code of Conduct](https://github.com/qbcore-fivem/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] My pull request title follows Conventional Commits, such as `fix(scope): ...` or `feat(scope): ...`.
- [x] This pull request contains one focused change and does not include unrelated formatting or refactoring.
- [x] I tested the change on a current FXServer artifact with the relevant official resources and dependencies.
- [x] Existing repository checks and linting pass.
- [x] I documented new behavior and identified every breaking or migration-related change.
- [x] I added or updated configuration examples, SQL migrations, and translations where applicable.
- [x] I removed credentials, webhook URLs, license keys, database data, player identifiers, and other private information.
- [x] I have the right to submit all included code and assets under the repository's license.
- [x] I understand and reviewed all submitted code, including any AI-assisted code, and accept responsibility for its correctness and licensing.
