### PR TITLE
fix Drops inside apartments

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -332,6 +332,10 @@ end)
 
 RegisterNetEvent('qb-inventory:server:updateDrop', function(dropId, coords)
     Drops[dropId].coords = coords
+    local entity = NetworkGetEntityFromNetworkId(Drops[dropId].entityId)
+    if DoesEntityExist(entity) then
+        SetEntityRoutingBucket(entity, GetPlayerRoutingBucket(source))
+    end
 end)
 
 RegisterNetEvent('qb-inventory:server:snowball', function(action)
@@ -364,6 +368,7 @@ QBCore.Functions.CreateCallback('qb-inventory:server:createDrop', function(sourc
         if item.type == 'weapon' then checkWeapon(src, item) end
         TaskPlayAnim(playerPed, 'pickup_object', 'pickup_low', 8.0, -8.0, 2000, 0, 0, false, false, false)
         local bag = CreateObjectNoOffset(Config.ItemDropObject, playerCoords.x + 0.5, playerCoords.y + 0.5, playerCoords.z, true, true, false)
+        SetEntityRoutingBucket(bag, GetPlayerRoutingBucket(src))
         local dropId = NetworkGetNetworkIdFromEntity(bag)
         local newDropId = 'drop-' .. dropId
         local itemsTable = setmetatable({ item }, {


### PR DESCRIPTION
fix Drops inside apartments

## Summary

Fixes dropped item bags not appearing when a player is inside an apartment or in another routing bucket.

Newly created drop entities are assigned to the player’s routing bucket in qb-inventory:server:createDrop. Existing drop entities are synchronized to the player’s routing bucket in qb-inventory:server:updateDrop, ensuring the bag remains visible in the correct virtual world.

## Screenshots or video
https://github.com/user-attachments/assets/984bc9d6-4b92-4938-adfc-c5a3c8b1845b

